### PR TITLE
Fix view search result keyword so user doesn't see stale info

### DIFF
--- a/app/views/keywords/_infor.html.haml
+++ b/app/views/keywords/_infor.html.haml
@@ -1,4 +1,4 @@
-- if local_assigns[:include_link] || false
+- if (local_assigns[:include_link] && keyword.status == 'success') || false
   %td= link_to(keyword.name, keyword_path(keyword))
 - else
   %td= keyword.name

--- a/app/views/keywords/_search_result_available.html.haml
+++ b/app/views/keywords/_search_result_available.html.haml
@@ -1,0 +1,14 @@
+.row
+  .col-md-8.offset-md-2
+    %h1= @keyword.name
+    %table.table.table-striped
+      - search_result = @keyword.search_result
+      %thead
+        %tr
+          = render 'search_result_headers'
+      %tbody
+        %tr
+          = render 'search_result_infor', search_result: search_result
+.row
+  .col-md-8.offset-md-2
+    = link_to "Back to keywords", keywords_path, class: "btn btn-secondary"

--- a/app/views/keywords/_search_result_infor.html.haml
+++ b/app/views/keywords/_search_result_infor.html.haml
@@ -1,4 +1,4 @@
-%td= search_result.adwords_advertisers
-%td= search_result.total_links
-%td= search_result.total_search_results
-%td= search_result.html
+%td= search_result&.adwords_advertisers
+%td= search_result&.total_links
+%td= search_result&.total_search_results
+%td= search_result&.html

--- a/app/views/keywords/_search_result_not_available.html.haml
+++ b/app/views/keywords/_search_result_not_available.html.haml
@@ -1,0 +1,5 @@
+.row
+  %h1 Search result for this keyword is not available yet or the keyword scraping failed.
+.row
+  .col-md-2
+    = link_to "Back to keywords", keywords_path, class: "btn btn-secondary"

--- a/app/views/keywords/show.html.haml
+++ b/app/views/keywords/show.html.haml
@@ -1,15 +1,6 @@
-.row
-  .col-md-8.offset-md-2
-    %h1= @keyword.name
-    %table.table.table-striped
-      %thead
-        %tr
-          = render 'search_result_headers'
-      - search_result = @keyword.search_result
-      %tbody
-        %tr
-          = render 'search_result_infor', search_result: search_result
+- if @keyword.status == 'success'
+  = render 'search_result_available', keyword: @keyword
+- else
+  = render 'search_result_not_available'
 
-.row
-  .col-md-8.offset-md-2
-    = link_to "Back to keywords", keywords_path, class: "btn btn-secondary"
+

--- a/spec/features/view_search_result_for_each_keyword_spec.rb
+++ b/spec/features/view_search_result_for_each_keyword_spec.rb
@@ -4,40 +4,73 @@ require 'rails_helper'
 
 RSpec.describe 'View search result information for each keyword' do
   let(:user) { create(:user) }
+  let!(:keyword) { create(:keyword, :success, user:, name: bitcoin) }
   let(:bitcoin) { 'Bitcoin' }
   let(:ethereum) { 'Ethereum' }
   let(:litecoin) { 'Litecoin' }
-  let!(:keyword) { create(:keyword, :success, user:, name: bitcoin) }
-  let(:search_result_attributes) do
-    keyword.search_result.attributes.except('id', 'keyword_id', 'updated_at', 'created_at')
-  end
-  let(:headers) { ['Total Number of AdWords', 'Total Number of Links', 'Total Search Results', 'HTML Source Code'] }
 
   context 'when user signs in' do
     before do
-      create(:keyword, :success, user:, name: ethereum)
-      create(:keyword, :success, user:, name: litecoin)
-
       sign_in user
-
-      visit keywords_path
-      link = find('a', text: keyword.name)
-      link.click
     end
 
-    it 'User views search result information for a keyword' do
-      expect(page).to have_current_path("/keywords/#{keyword.id}")
-    end
+    context 'when search result is available' do
+      before do
+        visit keywords_path
+        link = find('a', text: keyword.name)
+        link.click
+      end
 
-    it 'displays the correct table header' do
-      headers.each do |header|
-        expect(page).to have_selector('table.table.table-striped thead tr th', text: header)
+      let(:search_result_attributes) do
+        keyword.search_result.attributes.except('id', 'keyword_id', 'updated_at', 'created_at')
+      end
+      let(:headers) { ['Total Number of AdWords', 'Total Number of Links', 'Total Search Results', 'HTML Source Code'] }
+
+      it 'User views search result information for a keyword' do
+        expect(page).to have_current_path("/keywords/#{keyword.id}")
+      end
+
+      it 'displays the correct table header' do
+        headers.each do |header|
+          expect(page).to have_selector('table.table.table-striped thead tr th', text: header)
+        end
+      end
+
+      it 'displays search result info for a keyword' do
+        search_result_attributes.each do |_column_name, value|
+          expect(page).to have_content(value)
+        end
       end
     end
 
-    it 'displays search result info for a keyword' do
-      search_result_attributes.each do |_column_name, value|
-        expect(page).to have_content(value)
+    context 'when search result is not available' do
+      let!(:failed_keyword) { create(:keyword, :fail, user:, name: ethereum) }
+      let(:not_available_content) do
+        'Search result for this keyword is not available yet or the keyword scraping failed.'
+      end
+
+      context 'when user visit list of keywords page' do
+        before do
+          visit keywords_path
+        end
+
+        it 'does not have a link for the failed keyword' do
+          expect(page).not_to have_link(failed_keyword.name)
+        end
+      end
+
+      context 'when user visit the search result page' do
+        before do
+          visit keyword_path(failed_keyword.id)
+        end
+
+        it 'display the correct path for the failed keyword' do
+          expect(page).to have_current_path("/keywords/#{failed_keyword.id}")
+        end
+
+        it 'display content for keyword without search result' do
+          expect(page).to have_content(not_available_content)
+        end
       end
     end
   end


### PR DESCRIPTION
## Description
- Fix the search result view for failed/processing keywords so the users do not see the stale info 🐞
- Update related spec 📝 
- Extract view to partials for reusability 🧩

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## How Has This Been Tested?
- **Updated spec**:
  - View search result for each keyword spec

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] My changes generate no new warnings.
- [x] I have added necessary comments to the code where applicable, particularly in hard-to-understand areas.

## Screenshots (if appropriate):

## Additional context

Add any other context about the problem here.
